### PR TITLE
Bugfix reset form forgot pass and resend otp

### DIFF
--- a/lib/features/forgotpassword/view/forgot_password_form.dart
+++ b/lib/features/forgotpassword/view/forgot_password_form.dart
@@ -9,7 +9,6 @@ class ForgotPasswordForm extends StatefulWidget {
 
 class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
   late FToast fToast;
-  bool? resetForm;
 
   @override
   void initState() {
@@ -111,10 +110,6 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
             await prefs.setString('refresh_token',
               state.loginResponse.data.refresh_token,);
           }
-
-          if (state.forgotPassBadRequest == 'RECORD_NOT_FOUND') {
-            resetForm = true;
-          }
         },
         builder: (context, state) {
           return Stack(
@@ -122,7 +117,7 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
             children: [
               state.status.when(
                 initial: () {
-                  return ForgotPasswordFormUI(resetForm: resetForm,);
+                  return ForgotPasswordFormUI();
                 },
                 loading: () {
                   return Container();

--- a/lib/features/forgotpassword/view/forgot_password_form_ui.dart
+++ b/lib/features/forgotpassword/view/forgot_password_form_ui.dart
@@ -1,8 +1,7 @@
 part of 'forgot_password_page.dart';
 
 class ForgotPasswordFormUI extends StatefulWidget {
-  ForgotPasswordFormUI({super.key, this.resetForm});
-  bool? resetForm;
+  ForgotPasswordFormUI({super.key});
 
   @override
   ForgotPasswordFormUIState createState() => ForgotPasswordFormUIState();
@@ -30,10 +29,6 @@ class ForgotPasswordFormUIState extends State<ForgotPasswordFormUI> {
     context.read<ForgotPasswordBloc>().add(ForgotPasswordEvent.reqOtp(
         ResendOTPPost(email: strMerchantEmail!),
     ),);
-
-    if (widget.resetForm!) {
-      _formKey.currentState!.reset();
-    }
   }
 
   Future<void> _onSubmit() async {

--- a/lib/features/otp/view/otp_form.dart
+++ b/lib/features/otp/view/otp_form.dart
@@ -49,6 +49,12 @@ class OTPFormState extends State<OTPForm> {
     );
   }
 
+  _sendOTPInvalid(bool? invalidOTP) {
+    setState(() {
+      otpInvalid = invalidOTP!;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -65,16 +71,11 @@ class OTPFormState extends State<OTPForm> {
             );
 
             if (state.otpSuccess == 'OTPSUCCESS') {
-              final prefs = await SharedPreferences.getInstance();
-
-              await prefs.remove('otpInvalid');
               await context.push(AppRouter.homePath);
             }
 
             if (state.otpBadRequest == 'AUTH_OTP_INVALID') {
-              otpInvalid = true;
-              final prefs = await SharedPreferences.getInstance();
-              await prefs.setBool('otpInvalid', otpInvalid);
+              _sendOTPInvalid(true);
             }
           },
           builder: (context, state) {
@@ -83,7 +84,7 @@ class OTPFormState extends State<OTPForm> {
               children: [
                 state.status.when(
                   initial: () {
-                    return OTPFormUI();
+                    return OTPFormUI(otpInvalid: otpInvalid,);
                   },
                   loading: () {
                     return Container();

--- a/lib/features/otp/view/otp_form_ui.dart
+++ b/lib/features/otp/view/otp_form_ui.dart
@@ -1,8 +1,8 @@
 part of 'otp_page.dart';
 
 class OTPFormUI extends StatefulWidget {
-  OTPFormUI({super.key});
-
+  const OTPFormUI({super.key, this.otpInvalid});
+  final bool? otpInvalid;
   @override
   OTPFormUIState createState() => OTPFormUIState();
 }
@@ -11,16 +11,14 @@ class OTPFormUIState extends State<OTPFormUI> {
   final _formKey = GlobalKey<FormState>();
 
   String? strOTP;
-
   bool otpInteracts() => strOTP != null;
-  bool isShowOTPError = false;
   bool hideVerifikasiButton = true;
   bool showResendOtpButton = false;
   bool showCountDownTimer = false;
   bool disableResendOtpButton = false;
   var _isLoading = false;
   final pinController = TextEditingController();
-  var _countError = 0;
+  var _countError = 1;
 
   Future<void> _onSubmit() async {
     setState(() => _isLoading = true);
@@ -31,26 +29,23 @@ class OTPFormUIState extends State<OTPFormUI> {
 
     final prefs = await SharedPreferences.getInstance();
     late String email = prefs.getString('email') ?? '';
-    late bool otpInvalid = prefs.getBool('otpInvalid') ?? false;
 
     if (!context.mounted) return;
 
     context.read<OtpConfirmationBloc>().add(OtpConfirmationEvent.otpRequested(
         OtpConfirmationPost(email: email, otp_code: int.parse(strOTP!))));
 
-    isShowOTPError = otpInvalid;
     pinController.setText('');
 
-    if (otpInvalid) {
+    if (widget.otpInvalid!) {
       _countError += 1;
       strOTP = null;
     }
 
-    if (_countError % 3 == 0 && _countError != 0) {
+    if (_countError % 3 == 0) {
       hideVerifikasiButton = false;
       showResendOtpButton = true;
       strOTP != null;
-      await prefs.remove('otpInvalid');
     }
 
     if (showCountDownTimer) {
@@ -126,7 +121,6 @@ class OTPFormUIState extends State<OTPFormUI> {
                       AppSpacing.verticalSpacing32,
                       GestureDetector(
                         onTap: () {
-                          _countError = 0;
                           context.push(AppRouter.loginPath);
                         },
                         child: const Row(
@@ -161,7 +155,7 @@ class OTPFormUIState extends State<OTPFormUI> {
                         children: [
                           Flexible(
                             child: Visibility(
-                                visible: isShowOTPError,
+                                visible: widget.otpInvalid!,
                                 child: const Text(
                                   'Kode OTP tidak berlaku',
                                   softWrap: true,


### PR DESCRIPTION
Bugfix reset form forgot pass and resend otp appear

Related tickets :
1. [[Mobile] input OTP 4x wrong instead of 3x](https://mitrais-dev.atlassian.net/browse/MTK-5)
2. [[Mobile] spamming click upon KIRIM ULANG OTP button](https://mitrais-dev.atlassian.net/browse/MTK-7)
3. [[Mobile] User can only input invalid OTP once after click Kirim Ulang OTP](https://mitrais-dev.atlassian.net/browse/MTK-8)
4. [[Mobile] Late response UI](https://mitrais-dev.atlassian.net/browse/MTK-10)
5. [[Mobile] Input registered email after input unregistered email](https://mitrais-dev.atlassian.net/browse/MTK-37)

Evidence :

https://github.com/Mitra-Apps/fe-mobile-mitraku-seller/assets/27878239/6f352ddf-de14-4d70-83dc-c0ee0a7fcc2f

[MTK-37 Evidence](https://mitraisonline-my.sharepoint.com/:v:/g/personal/izharuddin_m901_mitrais_com/EQG7QUGf-XVMtXXXpmiueWoB9cREHljOPha7yn4SqsGQmA?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=ASEikH)